### PR TITLE
Bug#59 exit space: exit " 42 "のように数字がスペースとクォートに囲まれているとnumeric argument requiredが表示されてしまう

### DIFF
--- a/src/builtin/exec_builtin_exit.c
+++ b/src/builtin/exec_builtin_exit.c
@@ -23,7 +23,7 @@ bool	is_num(char *str)
 		i++;
 	while (str[i])
 	{
-		if (!isdigit(str[i]))
+		if (!isdigit(str[i]) && !isspace(str[i]))
 			return (false);
 		i++;
 	}


### PR DESCRIPTION
close #59 